### PR TITLE
feat: aggregate inventory cards

### DIFF
--- a/ops/GAS-change-search.md
+++ b/ops/GAS-change-search.md
@@ -1,0 +1,24 @@
+# GAS 追記（search_ に出荷済みカードを返す）
+
+対象: Apps Script プロジェクトの `search_` 関数  
+場所: 製造行ごとの在庫/未処理を push している for ループの末尾
+
+```js
+// ---- 出荷済み（合計）
+// logs.byRow[m.__rowNumber].shippedTotal が集計済み
+if (by.shippedTotal > 0) {
+  out.push({
+    rowIndex: m.__rowNumber,
+    manufactureDate: m.manufactureDate,
+    batchNo: m.batchNo,
+    seasoningType: m.seasoningType,
+    fishType: m.fishType,
+    origin: m.origin,
+    quantity: by.shippedTotal,            // 出荷合計
+    manufactureProduct: m.manufactureProduct,
+    status: '出荷済み',
+    packingInfo: { location: '', quantity: String(by.shippedTotal) }
+  });
+}
+```
+


### PR DESCRIPTION
## Summary
- display stock cards using actual inventory quantity
- group completed cards by row and location to avoid duplicates
- add Apps Script snippet for returning shipped cards

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b4fa4325788329b8057248c5821870