### PR TITLE
feat: add Next.js proxy API for GAS and route all GAS calls via /api/gas/*

### DIFF
--- a/src/pages/api/gas/[action].ts
+++ b/src/pages/api/gas/[action].ts
@@ -1,0 +1,35 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const GAS = process.env.GAS_WEBAPP_URL!; // 例: https://script.google.com/macros/s/XXXX/exec
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { action } = req.query as { action: string };
+
+  if (req.method === 'GET') {
+    const src = new URL(req.url!, 'http://localhost');
+    const dst = new URL(GAS);
+    dst.searchParams.set('action', action);
+    src.searchParams.forEach((v, k) => k !== 'action' && dst.searchParams.append(k, v));
+
+    const r = await fetch(dst.toString(), { cache: 'no-store' });
+    const text = await r.text();
+    res.status(r.status).setHeader('content-type', 'application/json');
+    try { res.send(JSON.parse(text)); } catch { res.send(text); }
+    return;
+  }
+
+  if (req.method === 'POST') {
+    const r = await fetch(GAS, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ...(req.body || {}), action }),
+      cache: 'no-store',
+    });
+    const text = await r.text();
+    res.status(r.status).setHeader('content-type', 'application/json').send(text);
+    return;
+  }
+
+  res.status(405).end();
+}
+

--- a/src/pages/api/packing/search.ts
+++ b/src/pages/api/packing/search.ts
@@ -33,7 +33,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
 
     const qs = new URLSearchParams(parsed.data as Record<string,string>).toString();
-    const r = await fetch(`${base}?action=search&${qs}`, { cache: "no-store" });
+    const r = await fetch(`/api/gas/search?${qs}`, { cache: "no-store" });
     const j = await r.json();
     return res.status(200).json(j);
   } catch (e:any) {

--- a/src/utils/logToSheet.ts
+++ b/src/utils/logToSheet.ts
@@ -13,10 +13,9 @@ export async function logToSheet(event: {
   operator?: string;
   note?: string;
 }) {
-  const url = process.env.GAS_WEBHOOK_URL!;
   const token = process.env.GAS_WEBHOOK_TOKEN!;
-  if (!url || !token) return;
-  await fetch(url, {
+  if (!token) return;
+  await fetch(`/api/gas/webhook`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', 'x-webhook-token': token },
     body: JSON.stringify(event),


### PR DESCRIPTION
## Summary
- add `/api/gas/[action]` proxy API to forward requests to GAS
- use `/api/gas` in existing server calls for search, update and logging

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b63c180f6c83299148618a949758cb