### PR TITLE
Allow 'ship_from_manu' in /api/packing/update

### DIFF
--- a/src/pages/api/packing/update.ts
+++ b/src/pages/api/packing/update.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { generateRequestId } from "../../../utils/requestId";
 
 const updateSchema = z.object({
-  action: z.enum(["pack", "ship", "move", "restore"]),
+  action: z.enum(["pack", "ship", "move", "restore", "ship_from_manu"]),
   rowIndex: z.number(),
   packingData: z.record(z.any()).optional(),
   payload: z.record(z.any()).optional(),


### PR DESCRIPTION
## Summary
- purpose: 製造列からの出荷で 400 となる問題の解消
- change: update.ts の Zod enum に "ship_from_manu" を追加
- impact: API リクエストのバリデーションのみ（他の挙動なし）

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_69044dc42df88329a63b12eb0488eb9e